### PR TITLE
Fix being able to insert 0 EMC items

### DIFF
--- a/src/main/java/net/lomeli/simplecondenser/tile/TileCondenserBase.java
+++ b/src/main/java/net/lomeli/simplecondenser/tile/TileCondenserBase.java
@@ -93,7 +93,7 @@ public class TileCondenserBase extends TileEntity implements ISidedInventory {
                 return ItemLib.isTome(stack);
             else if (slot == TARGET_SLOT && getStackInSlot(TARGET_SLOT) == null)
                 return isStackKnown(stack);
-        } else if (side > TARGET_SLOT)
+        } else if (slot > TARGET_SLOT)
             return (!matchesTarget(stack) && EnergyValueRegistryProxy.hasEnergyValue(stack));
         return false;
     }


### PR DESCRIPTION
You were previously checking if the side was greater than the target slot, instead of checking if the slot was :P
